### PR TITLE
Elimine redundancia de tamaño predeterminado

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,8 +1,6 @@
 @import "bootstrap/dist/css/bootstrap.min.css";
 
 .carta {
-  --ancho: 380px;
-  --alto: 500px;
   width: var(--ancho);
   height: var(--alto);
 }


### PR DESCRIPTION
Ya se esta escribiendo el tamaño predeterminado en Js:
const anchoCarta = parseInt(inAncho.value) || 380;
const altoCarta  = parseInt(inAlto.value)  || 500;